### PR TITLE
:twisted_rightwards_arrows: :: (#16) hotfix-secondary-domain-invalid-import

### DIFF
--- a/ida-secondary-domain/src/main/java/kr/hs/dgsw/cns/aggregate/secondary/domain/domain/Secondary.java
+++ b/ida-secondary-domain/src/main/java/kr/hs/dgsw/cns/aggregate/secondary/domain/domain/Secondary.java
@@ -1,6 +1,8 @@
 package kr.hs.dgsw.cns.aggregate.secondary.domain.domain;
 
-import kr.hs.dgsw.cns.aggregate.secondary.domain.domain.value.*;
+import kr.hs.dgsw.cns.aggregate.secondary.domain.value.Aptitude;
+import kr.hs.dgsw.cns.aggregate.secondary.domain.value.Examinee;
+import kr.hs.dgsw.cns.aggregate.secondary.domain.value.Interview;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;


### PR DESCRIPTION
2차 전형 도메인의 value 클래스의 잘못된 임포트 해결